### PR TITLE
fix: fix typo in the manual_seed torch method

### DIFF
--- a/01_introduction.ipynb
+++ b/01_introduction.ipynb
@@ -116,7 +116,7 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "torch.manual_seeed(0)"
+    "torch.manual_seed(0)"
    ]
   },
   {


### PR DESCRIPTION
fix typo in the manual_seed torch method